### PR TITLE
auto recognize the prompt ( i.e. "$> " )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@ testlogs
 ./minishell
 .gitignore
 minishell
+minishell1
+minishell2
+minishell3
+minishell4
+minishell5
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 testlogs
+./minishell
+.gitignore
+minishell
+.vscode

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ minishell_tester -u
 ## Usage
 ```
 cd <path to your local minishell repo with your Makefile>
-minishell_tester '<your_minishell_prompt_in_single_quotes>' [testnumber]
+minishell_tester [testnumber]
 ```
+*testnumber is Optional
 
 Example: Execute All Tests
 ```
@@ -37,7 +38,7 @@ minishell_tester 'minishell$ ' 5
 ## Interactive Mode
 To open interactive Mode, in which you can test any command:
 ```
-minishell_tester '<your_minishell_prompt_in_single_quotes>' -addtest
+minishell_tester -addtest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ minishell_tester [testnumber]
 
 Example: Execute All Tests
 ```
-minishell_tester 'minishell$ '
+minishell_tester
 ```
 
 Example: Execute Only Test No. 5
 ```
-minishell_tester 'minishell$ ' 5
+minishell_tester 5
 ```
 
 ## Interactive Mode

--- a/interactive.py
+++ b/interactive.py
@@ -14,6 +14,11 @@ else:
     print("Usage: python3 interactive.py '<your_minishell_prompt_in_single_quotes>'")
     exit(1)
 
+# Check if the minishell file exists
+if not os.path.isfile(MINISHELLPATH):
+    print("Error: minishell file not found in directory")
+    exit(1)
+
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'

--- a/minishell_tester.py
+++ b/minishell_tester.py
@@ -144,13 +144,13 @@ def get_minishell_prompt(shell_command):
 
     return prompt
 
+if not os.path.isfile(MINISHELLPATH):
+    print("Error: minishell file not found in directory")
+    exit(1)
 PROMPT = get_minishell_prompt([MINISHELLPATH])
 
 def main():
     # Check if the minishell file exists
-    if not os.path.isfile(MINISHELLPATH):
-        print("Error: minishell file not found in directory")
-        exit(1)
     # get the minishell prompt
     if PROMPT == "":
             print("Error: Could not get the prompt from minishell.")

--- a/minishell_tester.py
+++ b/minishell_tester.py
@@ -36,12 +36,6 @@ class bcolors:
 
 TESTLOGPATH = os.path.expandvars("$HOME") + "/minishell_tester/testlogs/"
 MINISHELLPATH = "./minishell"
-ARGC = len(sys.argv)
-for arg in sys.argv[1:]:
-    if '$' in arg:
-        os.environ['PROMPT'] = os.path.expandvars(arg)
-        PROMPT = os.path.expandvars(arg)
-        break
 
 def referenceresult(minishell, bash_result):
     try:
@@ -124,9 +118,14 @@ def execute_tests():
         print(bcolors.HEADER + "Executing Tests..." + bcolors.ENDC)
         for testnum, cmdlist in enumerate(TESTCMDS):
             test(cmdlist, testnum)
-
           
 def main():
+    # Check if the minishell file exists
+    PROMPT = ""
+    ARGC = len(sys.argv)
+    if not os.path.isfile(MINISHELLPATH):
+        print("Error: minishell file not found in directory")
+        exit(1)
     for arg in sys.argv[1:]:
         if '$' in arg:
             os.environ['PROMPT'] = os.path.expandvars(arg)
@@ -134,6 +133,10 @@ def main():
             break
     if "-addtest" in sys.argv or "--addtest" in sys.argv:
     # Use subprocess to run the update script
+        if PROMPT == "":
+            print("Error: No prompt specified")
+            print_usage()  
+            exit(1)
         subprocess.run(["python3", os.path.expandvars("$HOME") + "/minishell_tester/interactive.py", os.environ['PROMPT']])
         exit(0)
     if "-u" in sys.argv or "--update" in sys.argv:

--- a/minishell_tester.py
+++ b/minishell_tester.py
@@ -113,9 +113,9 @@ def print_logfile_info():
 
 def execute_tests():
     os.makedirs(TESTLOGPATH, exist_ok=True)
-    if ARGC > 2:
+    if ARGC > 1:
         print(bcolors.HEADER + "Executing Test..." + bcolors.ENDC)
-        test(TESTCMDS[int(sys.argv[2])], int(sys.argv[2]))
+        test(TESTCMDS[int(sys.argv[1])], int(sys.argv[1]))
     else:
         print(bcolors.HEADER + "Executing Tests..." + bcolors.ENDC)
         for testnum, cmdlist in enumerate(TESTCMDS):
@@ -170,8 +170,6 @@ def main():
         exit(0)
     print_welcome()
     build_minishell()
-    #output = subprocess.check_output(["./minishell"])
-    #print(output.decode())
     execute_tests()
     print_logfile_info()
 


### PR DESCRIPTION
add function to recognize the prompt i.e. "$> " automatically, without the need of entering it as an argument.
this makes it more user friendly.
there must be either a $  or  >  character in the prompt to parse it